### PR TITLE
Remove duplicate detectors

### DIFF
--- a/src/tqecd/construction.py
+++ b/src/tqecd/construction.py
@@ -9,6 +9,7 @@ from tqecd.flow import build_flows_from_fragments
 from tqecd.fragment import Fragment, FragmentLoop, split_stim_circuit_into_fragments
 from tqecd.match import MatchedDetector, match_detectors_from_flows_shallow
 from tqecd.predicates import is_valid_input_circuit
+from tqecd.utils import remove_duplicate_detectors
 
 
 def _detectors_to_circuit(
@@ -124,4 +125,4 @@ def compile_fragments_to_circuit_with_detectors(
                 )
                 * fragment.repetitions
             )
-    return circuit
+    return remove_duplicate_detectors(circuit)

--- a/src/tqecd/flow.py
+++ b/src/tqecd/flow.py
@@ -207,14 +207,6 @@ class FragmentLoopFlows:
         for i in sorted(indices, reverse=True):
             self.remove_destruction(i)
 
-    def without_trivial_flows(self) -> FragmentLoopFlows:
-        return FragmentLoopFlows(
-            fragment_flows=[
-                flow.without_trivial_flows() for flow in self.fragment_flows
-            ],
-            repeat=self.repeat,
-        )
-
     def try_merge_anticommuting_flows(self) -> None:
         _try_merge_anticommuting_flows_inplace(self.creation)
         _try_merge_anticommuting_flows_inplace(self.destruction)


### PR DESCRIPTION
Fixes #33.

The duplicated detectors in #33 are caused by the following:

1. Trivial flows are propagated and matched twice across two fragments — for example, [in this case](https://algassert.com/crumble#circuit=Q(0.5,1.5)0;Q(0.5,2.5)1;Q(0.5,3.5)2;Q(0.5,4.5)3;Q(0.5,5.5)4;Q(1,1)5;Q(1,2)6;Q(1,3)7;Q(1,4)8;Q(1,5)9;Q(1,6)10;Q(1.5,1.5)11;Q(1.5,2.5)12;Q(1.5,3.5)13;Q(1.5,4.5)14;Q(1.5,5.5)15;Q(2,1)16;Q(2,2)17;Q(2,3)18;Q(2,4)19;Q(2,5)20;Q(2,6)21;Q(2.5,0.5)22;Q(2.5,1.5)23;Q(2.5,2.5)24;Q(2.5,3.5)25;Q(2.5,4.5)26;Q(2.5,5.5)27;Q(3,1)28;Q(3,2)29;Q(3,3)30;Q(3,4)31;Q(3,5)32;Q(3,6)33;Q(3.5,1.5)34;Q(3.5,2.5)35;Q(3.5,3.5)36;Q(3.5,4.5)37;Q(3.5,5.5)38;Q(4,1)39;Q(4,2)40;Q(4,3)41;Q(4,4)42;Q(4,5)43;Q(4,6)44;Q(4.5,0.5)45;Q(4.5,1.5)46;Q(4.5,2.5)47;Q(4.5,3.5)48;Q(4.5,4.5)49;Q(4.5,5.5)50;Q(5,1)51;Q(5,2)52;Q(5,3)53;Q(5,4)54;Q(5,5)55;Q(5,6)56;Q(5.5,2.5)57;Q(5.5,4.5)58;R_5_16_28_39_51_52_40_29_17_6_7_18_30_41_53_54_42_31_19_8_9_20_32_43_55;TICK;R_11_34_24_22_45_47_49_36_13_26_38_15;RX_23_0_12_35_46_57_48_25_2_14_37_58;TICK;CX_17_11_40_34_51_45_28_22_19_13_30_24_53_47_42_36_55_49_32_26_23_29_46_52_0_6_12_18_35_41_48_54_25_31_2_8_14_20_37_43;TICK;CX_6_11_29_34_16_22_39_45_41_47_18_24_8_13_31_36_43_49_20_26_0_5_23_28_46_51_35_40_12_17_2_7_25_30_48_53_37_42_14_19;TICK;CX_16_11_39_34_52_47_29_24_18_13_41_36_54_49_31_26_20_15_43_38_23_17_46_40_35_30_12_7_25_19_48_42_37_32_14_9_57_53_58_55;TICK;CX_5_11_28_34_40_47_17_24_7_13_30_36_42_49_19_26_9_15_32_38_23_16_46_39_35_29_12_6_25_18_48_41_37_31_14_8_57_52_58_54;TICK;M_11_22_45_34_47_24_13_36_26_49_38_15;MX_0_23_46_57_35_12_2_25_48_58_37_14;TICK;R_11_34_24_22_45_47_49_36_13_26_38_15_10_21_33_44_56;RX_23_0_12_35_46_48_25_2_14_37_27_4_50_1_3_57_58;MARKX(0)57;TICK;CX_17_11_23_29_12_18_30_24_40_34_35_41_46_52_53_47_42_36_25_31_37_43_19_13_14_20_32_26_55_49_48_54_28_22_51_45_2_8_0_6_27_33_4_10_50_56_21_15_44_38;TICK;CX_6_11_23_28_12_17_18_24_29_34_16_22_35_40_25_30_31_36_41_47_8_13_20_26_43_49_37_42_48_53_46_51_39_45_14_19_2_7_27_32_50_55_33_38_4_9_10_15_0_5;TICK;CX_7_12_17_23_11_16_24_29_34_39_30_35_36_41_42_48_49_54_55_58_13_18_19_25_26_31_32_37_38_43_9_14_15_20_40_46_47_52_53_57_21_27_44_50_1_6_3_8;TICK;CX_24_30_34_40_31_25_41_35_36_42_11_17_18_12_29_23_13_19_20_14_26_32_47_53_54_48_43_37_49_55_52_46_15_21_33_27_38_44_56_50_10_4_6_0_1_7_3_9_8_2;TICK;M_12_35_48_25_37_14_27_50_22_23_46_45_16_28_39_51_5;MX_24_47_13_36_49_26_38_15_11_34_0_2_1_3_57_58;MARKX(0)57;TICK;M_6_17_29_40_52_53_41_30_18_7_8_9_10_21_20_19_31_32_33_44_56_55_42_43_54;OI(0)rec[-13]_rec[-14]_rec[-15]_rec[-16]_rec[-25]_rec[-42]). As a side note, in fact, we can simplify the circuit by removing all operations (RX + CNOT + MX) on the two rightmost qubits during the sliding round.
2. For [this detector](https://algassert.com/crumble#circuit=Q(0.5,1.5)0;Q(0.5,2.5)1;Q(0.5,3.5)2;Q(0.5,4.5)3;Q(0.5,5.5)4;Q(1,1)5;Q(1,2)6;Q(1,3)7;Q(1,4)8;Q(1,5)9;Q(1,6)10;Q(1.5,1.5)11;Q(1.5,2.5)12;Q(1.5,3.5)13;Q(1.5,4.5)14;Q(1.5,5.5)15;Q(2,1)16;Q(2,2)17;Q(2,3)18;Q(2,4)19;Q(2,5)20;Q(2,6)21;Q(2.5,0.5)22;Q(2.5,1.5)23;Q(2.5,2.5)24;Q(2.5,3.5)25;Q(2.5,4.5)26;Q(2.5,5.5)27;Q(3,1)28;Q(3,2)29;Q(3,3)30;Q(3,4)31;Q(3,5)32;Q(3,6)33;Q(3.5,1.5)34;Q(3.5,2.5)35;Q(3.5,3.5)36;Q(3.5,4.5)37;Q(3.5,5.5)38;Q(4,1)39;Q(4,2)40;Q(4,3)41;Q(4,4)42;Q(4,5)43;Q(4,6)44;Q(4.5,0.5)45;Q(4.5,1.5)46;Q(4.5,2.5)47;Q(4.5,3.5)48;Q(4.5,4.5)49;Q(4.5,5.5)50;Q(5,1)51;Q(5,2)52;Q(5,3)53;Q(5,4)54;Q(5,5)55;Q(5,6)56;Q(5.5,2.5)57;Q(5.5,4.5)58;R_5_16_28_39_51_52_40_29_17_6_7_18_30_41_53_54_42_31_19_8_9_20_32_43_55;TICK;R_11_34_24_22_45_47_49_36_13_26_38_15;RX_23_0_12_35_46_57_48_25_2_14_37_58;TICK;CX_17_11_40_34_51_45_28_22_19_13_30_24_53_47_42_36_55_49_32_26_23_29_46_52_0_6_12_18_35_41_48_54_25_31_2_8_14_20_37_43;TICK;CX_6_11_29_34_16_22_39_45_41_47_18_24_8_13_31_36_43_49_20_26_0_5_23_28_46_51_35_40_12_17_2_7_25_30_48_53_37_42_14_19;TICK;CX_16_11_39_34_52_47_29_24_18_13_41_36_54_49_31_26_20_15_43_38_23_17_46_40_35_30_12_7_25_19_48_42_37_32_14_9_57_53_58_55;TICK;CX_5_11_28_34_40_47_17_24_7_13_30_36_42_49_19_26_9_15_32_38_23_16_46_39_35_29_12_6_25_18_48_41_37_31_14_8_57_52_58_54;TICK;M_11_22_45_34_47_24_13_36_26_49_38_15;MX_0_23_46_57_35_12_2_25_48_58_37_14;TICK;R_11_34_24_22_45_47_49_36_13_26_38_15_10_21_33_44_56;RX_23_0_12_35_46_48_25_2_14_37_27_4_50_1_3_57_58;MARKZ(0)21_33;TICK;CX_17_11_23_29_12_18_30_24_40_34_35_41_46_52_53_47_42_36_25_31_37_43_19_13_14_20_32_26_55_49_48_54_28_22_51_45_2_8_0_6_27_33_4_10_50_56_21_15_44_38;TICK;CX_6_11_23_28_12_17_18_24_29_34_16_22_35_40_25_30_31_36_41_47_8_13_20_26_43_49_37_42_48_53_46_51_39_45_14_19_2_7_27_32_50_55_33_38_4_9_10_15_0_5;TICK;CX_7_12_17_23_11_16_24_29_34_39_30_35_36_41_42_48_49_54_55_58_13_18_19_25_26_31_32_37_38_43_9_14_15_20_40_46_47_52_53_57_21_27_44_50_1_6_3_8;TICK;CX_24_30_34_40_31_25_41_35_36_42_11_17_18_12_29_23_13_19_20_14_26_32_47_53_54_48_43_37_49_55_52_46_15_21_33_27_38_44_56_50_10_4_6_0_1_7_3_9_8_2;TICK;M_12_35_48_25_37_14_27_50_22_23_46_45_16_28_39_51_5;MX_24_47_13_36_49_26_38_15_11_34_0_2_1_3_57_58;MARKZ(0)27;TICK;M_6_17_29_40_52_53_41_30_18_7_8_9_10_21_20_19_31_32_33_44_56_55_42_43_54;OI(0)rec[-13]_rec[-14]_rec[-15]_rec[-16]_rec[-25]_rec[-42]), the start boundary stabilizer produces a non-propagating flow (i.e., a detector). However, in the next matching round, the two propagating anti-commuting flows from the resets generate another detector, duplicating the previous one.

This PR applies a simple fix by removing duplicated detectors in post-processing.