### PR TITLE
Optionally reuse flows for anti-commuting covers

### DIFF
--- a/src/tqecd/construction_test.py
+++ b/src/tqecd/construction_test.py
@@ -85,3 +85,27 @@ def test_invalid_circuits(name: str, circuit: stim.Circuit, error_message: str) 
     )
     with pytest.raises(TQECDException, match=rf"^{error_message}$"):
         annotate_detectors_automatically(circuit_without_detectors)
+
+
+def test_reuse_flows_for_anticommuting_cover() -> None:
+    circuit = stim.Circuit("""
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(1, 0) 1
+QUBIT_COORDS(2, 0) 2
+R 0 1 2
+TICK
+CX 1 0
+TICK
+CX 1 2
+TICK
+MX 1
+TICK
+M 0 2
+""")
+    assert annotate_detectors_automatically(circuit).num_detectors == 1
+    assert (
+        annotate_detectors_automatically(
+            circuit, reuse_flows_for_anticommuting_cover=True
+        ).num_detectors
+        == 2
+    )

--- a/src/tqecd/flow.py
+++ b/src/tqecd/flow.py
@@ -101,7 +101,7 @@ def _try_merge_anticommuting_flows_inplace(
         # 2. Flows remain valid for finding subsequent merging opportunities,
         #    as the removed flow's anti-commuting boundary stabilizer is covered
         #    by the remaining flows.
-        # Note that we have the risk that the reused flows may have unecessarily
+        # Note that we have the risk that the reused flows may have unnecessarily
         # many measurements included in the formed detector. However, we never
         # guarantee minimality of detector structures, so this is not an issue.
         if reuse_flows:

--- a/src/tqecd/flow.py
+++ b/src/tqecd/flow.py
@@ -87,10 +87,17 @@ def _try_merge_anticommuting_flows_inplace(flows: list[BoundaryStabilizer]) -> N
         stabilizers_to_merge: list[BoundaryStabilizer] = [
             flows[i] for i in flows_indices_of_stabilizers_to_merge
         ]
-        # Update the flows by removing the entries related to stabilizers that
-        # will be merged and re-compute the anti-commuting stabilizers and map.
-        for i in sorted(flows_indices_of_stabilizers_to_merge, reverse=True):
-            flows.pop(i)
+        # Update flows: remove one entry per merged stabilizer.
+        # This ensures:
+        # 1. A stabilizer isn't merged twice.
+        # 2. Flows remain valid for finding subsequent merging opportunities,
+        #    as the removed flow's anti-commuting boundary stabilizer is covered
+        #    by the remaining flows.
+        # Note that we have the risk that the reused flows may have unecessarily
+        # many measurements included in the formed detector. However, we never
+        # guarantee minimality of detector structures, so this is not an issue.
+        flows.pop(flows_indices_of_stabilizers_to_merge[-1])
+
         anti_commuting_index_to_flows_index = _anti_commuting_stabilizers_indices(flows)
         anticommuting_stabilizers = [
             flows[fi].before_collapse for fi in anti_commuting_index_to_flows_index

--- a/src/tqecd/flow.py
+++ b/src/tqecd/flow.py
@@ -15,7 +15,9 @@ def _anti_commuting_stabilizers_indices(flows: list[BoundaryStabilizer]) -> list
     return [i for i in range(len(flows)) if flows[i].has_anticommuting_operations]
 
 
-def _try_merge_anticommuting_flows_inplace(flows: list[BoundaryStabilizer]) -> None:
+def _try_merge_anticommuting_flows_inplace(
+    flows: list[BoundaryStabilizer], reuse_flows: bool = False
+) -> None:
     """Merge as much anti-commuting flows as possible from the provided flows.
 
     This function try to merge together several :class:`BoundaryStabilizer`
@@ -27,6 +29,12 @@ def _try_merge_anticommuting_flows_inplace(flows: list[BoundaryStabilizer]) -> N
     Args:
         flows: a list of flows that might or might not contains flows that
             anti-commute with its collapsing operations.
+        reuse_flows: if True, the flows that are used to form a commuting
+            stabilizer are not all removed from the list of flows. Instead,
+            only one of them is removed, and the others are kept to be potentially
+            reused to form other commuting stabilizers. This might lead to
+            detectors involving more measurements than necessary, but it allows
+            to find more detectors in some cases. Defaults to False.
 
     Raises:
         TQECDException: if the provided flows have different collapsing
@@ -96,7 +104,11 @@ def _try_merge_anticommuting_flows_inplace(flows: list[BoundaryStabilizer]) -> N
         # Note that we have the risk that the reused flows may have unecessarily
         # many measurements included in the formed detector. However, we never
         # guarantee minimality of detector structures, so this is not an issue.
-        flows.pop(flows_indices_of_stabilizers_to_merge[-1])
+        if reuse_flows:
+            flows.pop(flows_indices_of_stabilizers_to_merge[-1])
+        else:
+            for i in sorted(flows_indices_of_stabilizers_to_merge, reverse=True):
+                flows.pop(i)
 
         anti_commuting_index_to_flows_index = _anti_commuting_stabilizers_indices(flows)
         anticommuting_stabilizers = [
@@ -165,9 +177,11 @@ class FragmentFlows:
             total_number_of_measurements=self.total_number_of_measurements,
         )
 
-    def try_merge_anticommuting_flows(self) -> None:
-        _try_merge_anticommuting_flows_inplace(self.creation)
-        _try_merge_anticommuting_flows_inplace(self.destruction)
+    def try_merge_anticommuting_flows(self, reuse_flows: bool = False) -> None:
+        _try_merge_anticommuting_flows_inplace(self.creation, reuse_flows=reuse_flows)
+        _try_merge_anticommuting_flows_inplace(
+            self.destruction, reuse_flows=reuse_flows
+        )
 
 
 @dataclass
@@ -214,9 +228,11 @@ class FragmentLoopFlows:
         for i in sorted(indices, reverse=True):
             self.remove_destruction(i)
 
-    def try_merge_anticommuting_flows(self) -> None:
-        _try_merge_anticommuting_flows_inplace(self.creation)
-        _try_merge_anticommuting_flows_inplace(self.destruction)
+    def try_merge_anticommuting_flows(self, reuse_flows: bool = False) -> None:
+        _try_merge_anticommuting_flows_inplace(self.creation, reuse_flows=reuse_flows)
+        _try_merge_anticommuting_flows_inplace(
+            self.destruction, reuse_flows=reuse_flows
+        )
 
 
 def build_flows_from_fragments(


### PR DESCRIPTION
This issue is found by one of my colleagues (Weiping Lin).

For the following circuit:

```txt
QUBIT_COORDS(0, 0) 0
QUBIT_COORDS(1, 0) 1
QUBIT_COORDS(2, 0) 2
R 0 1 2
TICK
CX 1 0
TICK
CX 1 2
TICK
MX 1
TICK
M 0 2
```

There should be two detectors `DETECTOR rec[-1]` and `DETECTOR rec[-2]`. However, `annotate_detectors_automatically` returns a single detector `DETECTOR rec[-1] rec[-2]`. This is because in https://github.com/tqec/tqecd/blob/7e47c3957c6c537be9f4eff9747930bee80f6c35/src/tqecd/flow.py#L90-L93 Every used flow is immediately removed and cannot be used anymore. 

This PR adds an option to reuse the flows for further anticommuting cover opportunities. It's achieved by removing a single flow instead of all the flows each time. Note that it will significantly increase the runtime when this option is on but it enables more opportunities to find complete detectors.