### PR TITLE
Make mypy ignore docs folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ warn_redundant_casts = true
 # Explicitly disable that for the moment, will eventually be turned on again.
 warn_unused_ignores = false
 warn_unreachable = true
+exclude = ["docs/"]
 
 # Getting these passing should be easy
 strict_equality = true


### PR DESCRIPTION
Address #56 and by extension #55 

Ignores formatting in `conf.py` only, so mypy only has to check the actual code.

## Testing

`uv run mypy .`