### PR TITLE
Skip write-only workflow steps for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
           thresholds: "50 75"
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: code-coverage
           recreate: true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,14 +40,18 @@ jobs:
           publish_dir: ./docs/_build/html/
       - name: Deploy if PR
         uses: peaceiris/actions-gh-pages@v4
-        if: github.ref != 'refs/heads/main'
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html/
           destination_dir: ./pull/${{github.event.number}}/
       - name: Add comment if PR
         uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: documentation-preview
           recreate: true


### PR DESCRIPTION
## Summary

- skip the write-only coverage PR comment for pull requests from forks
- skip the GitHub Pages deployment and sticky preview comment for fork pull requests
- continue building documentation and running all read-only CI steps for fork pull requests
- preserve preview deployment behavior for same-repository pull requests

These changes were extracted from #63 at the maintainer's request so they can be reviewed and merged independently.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/gh-pages.yml`
- parsed both workflows with PyYAML
- `git diff --check origin/main...HEAD`