### PR TITLE
Lift the numpy<2.3 upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "numpy>=1.22,<2.3",                      # Upper bound: https://github.com/tqec/tqec/pull/659
+    "numpy>=1.22",
     "numpy>=1.24; python_version >= '3.11'",
     "numpy>=1.26; python_version >= '3.12'",
     "numpy>=2.1; python_version >= '3.13'",


### PR DESCRIPTION
Closes #70.

## Summary

Removes the `numpy<2.3` upper bound in `pyproject.toml` so `tqecd` can install and run against numpy ≥ 2.3.

The cap was added to avoid `mypy` failures reported under numpy ≥ 2.3 (tqec/tqec#613). Those failures came from numpy's typing stubs and have since been resolved upstream, so the cap is no longer needed. This is a **metadata-only change — no source edits**.

## Change

```diff
 dependencies = [
-    "numpy>=1.22,<2.3",                      # Upper bound: https://github.com/tqec/tqec/pull/659
+    "numpy>=1.22",
     "numpy>=1.24; python_version >= '3.11'",
     "numpy>=1.26; python_version >= '3.12'",
     "numpy>=2.1; python_version >= '3.13'",

The per-Python lower bounds are unchanged. Since numpy ≥ 2.3 drops Python 3.10, the resolver automatically keeps numpy 2.2.x on 3.10 and picks the latest numpy on 3.11+.

## Validation

Ran mypy src/tqecd and the full test suite locally across the matrix, plus
pre-commit run --all-files (all hooks pass):

┌────────┬──────────────┬────────────────┬────────────────────┐
│ Python │    numpy     │ mypy src/tqecd │ pytest (123 tests) │
├────────┼──────────────┼────────────────┼────────────────────┤
│ 3.10   │ 2.2.6 (auto) │ clean          │ 123 passed         │
├────────┼──────────────┼────────────────┼────────────────────┤
│ 3.12   │ 2.3.5        │ clean          │ 123 passed         │
├────────┼──────────────┼────────────────┼────────────────────┤
│ 3.12   │ 2.4.6        │ clean          │ 123 passed         │
├────────┼──────────────┼────────────────┼────────────────────┤
│ 3.12   │ 2.5.1        │ clean          │ 123 passed         │
└────────┴──────────────┴────────────────┴────────────────────┘

No source changes were needed to reach green at any version.

Notes

- numpy.typing.mypy_plugin deprecation: numpy 2.3 deprecates the plugin referenced in [tool.mypy] ("will be removed in a future release"). It still works, and mypy stays clean with it removed – I left it in place to keep this PR single-purpose, but
happy to drop it here or as a follow-up if you'd prefer.
- Release step: merging alone doesn't publish (PyPI publish is tag-gated). Once you're able to cut a tqecd release, I'll bump tqecd>=<new> on the tqec side to unblock tqec/tqec#977.

## AI assistance disclosure

Claude Code assisted with the cross-repo investigation, the numpy version-matrix reproduction, the local mypy/pytest verification. I have myself reviewed the change and the validation results – the single-line dependency edit and the per-version green runs were inspected and confirmed before submitting.

Unblocks tqec/tqec#613 and tqec/tqec#977.